### PR TITLE
black: remove --preview

### DIFF
--- a/scripts/format-code.sh
+++ b/scripts/format-code.sh
@@ -182,7 +182,7 @@ function do_beautysh_sh() {
 LINTER_REQUIRE+=([black]="black")
 LINTER_TYPES+=([black]="python")
 function do_black() {
-    black -l 79 --preview "$@"
+    black -l 79 "$@"
 }
 
 LINTER_REQUIRE+=([eslint]="eslint;.eslintrc.json;${CONFIG_PATH}/eslint-global-config.json")


### PR DESCRIPTION
The --preview option is more likely to cause churn in our Python formatting.  Disable it.

I believe this is causing failures in bmcweb that arent seen upstream. 
Pull this in. This actually means less checking. 
Upstream is merged at https://gerrit.openbmc.org/c/openbmc/openbmc-build-scripts/+/60935

https://github.com/ibm-openbmc/bmcweb/pull/653
https://github.com/ibm-openbmc/bmcweb/pull/654 are PR failing with 
```
    Running shellcheck
    Result differences...
diff --git a/scripts/parse_registries.py b/scripts/parse_registries.py
index c23ed36b..2e8a23f0 100755
--- a/scripts/parse_registries.py
+++ b/scripts/parse_registries.py
@@ -19,10 +19,7 @@ WARNING = """/****************************************************************
  * github organization.
  ***************************************************************/"""
 
-REGISTRY_HEADER = (
-    PRAGMA_ONCE
-    + WARNING
-    + """
+REGISTRY_HEADER = PRAGMA_ONCE + WARNING + """
 #include "registries.hpp"
 
 #include <array>
@@ -32,7 +29,6 @@ REGISTRY_HEADER = (
 namespace redfish::registries::{}
 {{
 """
-)
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 
@@ -173,10 +169,7 @@ def create_Subordinate_Overrides(target_list):
     return target_list_create
 
 
-PRIVILEGE_HEADER = (
-    PRAGMA_ONCE
-    + WARNING
-    + """
+PRIVILEGE_HEADER = PRAGMA_ONCE + WARNING + """
 #include "privileges.hpp"
 
 #include <array>
@@ -186,7 +179,6 @@ PRIVILEGE_HEADER = (
 namespace redfish::privileges
 {
 """
-)
 
 
 def make_privilege_registry():
Format: FAILED

```

Change-Id: I96e6e7fbd6607c478ca38c5de8a0db0c30b180a5