### PR TITLE
Audit Log: Build linux audit-userspace to provide audit libraries

### DIFF
--- a/scripts/build-unit-test-docker
+++ b/scripts/build-unit-test-docker
@@ -159,6 +159,23 @@ packages = {
         rev="json-c-0.16-20220414",
         build_type="cmake",
     ),
+    "linux-audit/audit-userspace": PackageDef(
+        rev="3.1.2",
+        url=(
+            lambda pkg, rev: f"https://github.com/{pkg}/archive/refs/tags/v{rev}.tar.gz"
+        ),
+        build_type="make",
+        custom_post_dl=["./autogen.sh",
+        f"./configure --prefix={prefix} --enable-gssapi-krb5=no \
+                --libdir={prefix}/lib/x86_64-linux-gnu \
+                --with-libcap-ng=no \
+                --with-python3=no \
+                --with-python=no \
+                --without-golang \
+                --disable-zos-remote \
+                --with-arm=no \
+                --with-aarch64=yes"],
+    ),
     # Snapshot from 2019-05-24
     "linux-test-project/lcov": PackageDef(
         rev="v1.15",
@@ -197,6 +214,7 @@ packages = {
     "ibm-openbmc/phosphor-logging": PackageDef(
         depends=[
             "USCiLab/cereal",
+            "linux-audit/audit-userspace",
             "ibm-openbmc/phosphor-dbus-interfaces",
             "openbmc/sdbusplus",
             "openbmc/sdeventplus",


### PR DESCRIPTION
phosphor-logging new D-Bus service phosphor-auditlog requires the libauparse library.

This combined with an update to the phosphor-logging/phosphor-auditlog/meson.build allowed CI to pass in my sandbox.

I'm assuming this PR has to be merged before I can get the phosphor-logging PR (https://github.com/ibm-openbmc/phosphor-logging/pull/41) to pass the CI and be allowed to merge.