### PR TITLE
Audit Log: Correct building of linux audit-userspace

### DIFF
--- a/scripts/build-unit-test-docker
+++ b/scripts/build-unit-test-docker
@@ -46,6 +46,13 @@ except Exception:
 prefix = "/usr/local"
 proc_count = nproc().strip()
 
+# Determine the library path based on architecture
+arch = uname("-m").strip()
+if arch == "ppc64le":
+    libbase = "powerpc64le-linux-gnu/"
+else:
+    # All others use architecture name
+    libbase = f"{arch}-linux-gnu/"
 
 class PackageDef(TypedDict, total=False):
     """Package Definition for packages dictionary."""
@@ -166,8 +173,10 @@ packages = {
         ),
         build_type="make",
         custom_post_dl=["./autogen.sh",
-        f"./configure --prefix={prefix} --enable-gssapi-krb5=no \
-                --libdir={prefix}/lib/x86_64-linux-gnu \
+        f"./configure --prefix={prefix} \
+                --exec-prefix={prefix} \
+                --libdir={prefix}/lib/{libbase} \
+                --enable-gssapi-krb5=no \
                 --with-libcap-ng=no \
                 --with-python3=no \
                 --with-python=no \
@@ -689,7 +698,6 @@ if username == "root":
     uid = 0
 
 # Determine the architecture for Docker.
-arch = uname("-m").strip()
 if arch == "ppc64le":
     docker_base = "ppc64le/"
 elif arch == "x86_64":


### PR DESCRIPTION
Audit Log: Correct building of linux audit-userspace

The library install path for the audit-userspace libraries is architecture dependent. Corrected how this is determined.