### PR TITLE
Audit Log: 1110 rebase audit log PRs #14 & #15

### DIFF
--- a/scripts/build-unit-test-docker
+++ b/scripts/build-unit-test-docker
@@ -158,6 +158,23 @@ packages = {
         rev="json-c-0.17-20230812",
         build_type="cmake",
     ),
+    "linux-audit/audit-userspace": PackageDef(
+        rev="3.1.2",
+        url=(
+            lambda pkg, rev: f"https://github.com/{pkg}/archive/refs/tags/v{rev}.tar.gz"
+        ),
+        build_type="make",
+        custom_post_dl=["./autogen.sh",
+        f"./configure --prefix={prefix} --enable-gssapi-krb5=no \
+                --libdir={prefix}/lib/x86_64-linux-gnu \
+                --with-libcap-ng=no \
+                --with-python3=no \
+                --with-python=no \
+                --without-golang \
+                --disable-zos-remote \
+                --with-arm=no \
+                --with-aarch64=yes"],
+    ),
     "linux-test-project/lcov": PackageDef(
         rev="v1.16",
         build_type="make",
@@ -195,6 +212,7 @@ packages = {
     "openbmc/phosphor-logging": PackageDef(
         depends=[
             "USCiLab/cereal",
+            "linux-audit/audit-userspace",
             "ibm-openbmc/phosphor-dbus-interfaces",
             "openbmc/sdbusplus",
             "openbmc/sdeventplus",

--- a/scripts/build-unit-test-docker
+++ b/scripts/build-unit-test-docker
@@ -46,6 +46,13 @@ except Exception:
 prefix = "/usr/local"
 proc_count = nproc().strip()
 
+# Determine the library path based on architecture
+arch = uname("-m").strip()
+if arch == "ppc64le":
+    libbase = "powerpc64le-linux-gnu/"
+else:
+    # All others use architecture name
+    libbase = f"{arch}-linux-gnu/"
 
 class PackageDef(TypedDict, total=False):
     """Package Definition for packages dictionary."""
@@ -165,8 +172,10 @@ packages = {
         ),
         build_type="make",
         custom_post_dl=["./autogen.sh",
-        f"./configure --prefix={prefix} --enable-gssapi-krb5=no \
-                --libdir={prefix}/lib/x86_64-linux-gnu \
+        f"./configure --prefix={prefix} \
+                --exec-prefix={prefix} \
+                --libdir={prefix}/lib/{libbase} \
+                --enable-gssapi-krb5=no \
                 --with-libcap-ng=no \
                 --with-python3=no \
                 --with-python=no \
@@ -693,7 +702,6 @@ if username == "root":
     uid = 0
 
 # Determine the architecture for Docker.
-arch = uname("-m").strip()
 if arch == "ppc64le":
     docker_base = "ppc64le/"
 elif arch == "x86_64":


### PR DESCRIPTION
Rebase to 1110 PRs needed for Audit Log support.

Audit Log: Build linux audit-userspace to provide audit libraries (https://github.com/ibm-openbmc/openbmc-build-scripts/pull/14)

phosphor-logging new D-Bus service phosphor-auditlog requires the
libauparse library.

 Audit Log: Correct building of linux audit-userspace (https://github.com/ibm-openbmc/openbmc-build-scripts/pull/15)

The library install path for the audit-userspace libraries is
architecture dependent. Corrected how this is determined.