### PR TITLE
detect-secrets: add in IBM secret scanner

### DIFF
--- a/scripts/build-unit-test-docker
+++ b/scripts/build-unit-test-docker
@@ -859,6 +859,8 @@ RUN apt-get update && apt-get dist-upgrade -yy && apt-get install -yy \
     wget \
     xxd
 
+RUN pip install --break-system-packages --upgrade "git+https://github.com/ibm/detect-secrets.git@master#egg=detect-secrets"
+
 RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 13 \
   --slave /usr/bin/g++ g++ /usr/bin/g++-13 \
   --slave /usr/bin/gcov gcov /usr/bin/gcov-13 \

--- a/scripts/format-code.sh
+++ b/scripts/format-code.sh
@@ -37,6 +37,7 @@ LINTERS_ALL=( \
         markdownlint \
         prettier \
         shellcheck \
+        detect_secrets \
     )
 LINTERS_DISABLED=()
 LINTERS_ENABLED=()
@@ -241,6 +242,13 @@ function do_clang_format() {
     "${CLANG_FORMAT}" -i "$@"
 }
 
+LINTER_REQUIRE+=([detect_secrets]="detect-secrets;.secrets.baseline")
+LINTER_TYPES+=([detect_secrets]="c;cpp;bash;sh;json;python")
+function do_detect_secrets() {
+    detect-secrets scan --update .secrets.baseline
+    detect-secrets audit --report --fail-on-unaudited --fail-on-live --fail-on-audited-real .secrets.baseline
+}
+
 function get_file_type()
 {
     case "$(basename "$1")" in
@@ -397,7 +405,10 @@ fi
 # Check for differences.
 if [ -z "$OPTION_NO_DIFF" ]; then
     echo -e "    ${BLUE}Result differences...${NORMAL}"
-    if ! git --no-pager diff --exit-code ; then
+    # .secrets.baseline will have its date updated everytime we run so
+    # just restore it
+    git restore .secrets.baseline
+    if ! git --no-pager diff --exit-code; then
         echo -e "Format: ${RED}FAILED${NORMAL}"
         exit 1
     else


### PR DESCRIPTION
If a repository has a .secrets.baseline then the current commit will be scanned for any new secrets and fail the CI job if any are found.