### PR TITLE
build-unit-test-docker: ubuntu: switch to noble numbat

### DIFF
--- a/scripts/build-unit-test-docker
+++ b/scripts/build-unit-test-docker
@@ -673,7 +673,7 @@ docker_image_name = os.environ.get(
 )
 force_build = os.environ.get("FORCE_DOCKER_BUILD")
 is_automated_ci_build = os.environ.get("BUILD_URL", False)
-distro = os.environ.get("DISTRO", "ubuntu:mantic")
+distro = os.environ.get("DISTRO", "ubuntu:noble")
 branch = os.environ.get("BRANCH", "master")
 ubuntu_mirror = os.environ.get("UBUNTU_MIRROR")
 http_proxy = os.environ.get("http_proxy")


### PR DESCRIPTION
The clang-17 package in manic is pinned back at 17.0.2, while the latest release is 17.0.6.  There are some subtle bug fixes around type parsing, which are especially useful for clang-format.  Upgrade the distro so we can get these fixes.


Change-Id: I53dce7c01bc04cbff193fd660984f2eb985be91a