### PR TITLE
1050: move to ubuntu noble

### DIFF
--- a/scripts/build-unit-test-docker
+++ b/scripts/build-unit-test-docker
@@ -637,7 +637,7 @@ docker_image_name = os.environ.get(
 )
 force_build = os.environ.get("FORCE_DOCKER_BUILD")
 is_automated_ci_build = os.environ.get("BUILD_URL", False)
-distro = os.environ.get("DISTRO", "ubuntu:lunar")
+distro = os.environ.get("DISTRO", "ubuntu:noble")
 branch = os.environ.get("BRANCH", "master")
 ubuntu_mirror = os.environ.get("UBUNTU_MIRROR")
 http_proxy = os.environ.get("http_proxy")
@@ -796,7 +796,6 @@ RUN apt-get update && apt-get dist-upgrade -yy && apt-get install -yy \
     sudo \
     systemd \
     valgrind \
-    valgrind-dbg \
     vim \
     wget \
     xxd


### PR DESCRIPTION
Ubuntu lunar has lost support so switch to an LTS but keep all of the older packages that we need for 1050. The only package not available is valgrind-dbg and we don't need that for CI.