### PR TITLE
build-unit-test-docker: pin sdbusplus

### DIFF
--- a/scripts/build-unit-test-docker
+++ b/scripts/build-unit-test-docker
@@ -268,6 +268,7 @@ packages = {
         config_flags=["-Dabi=deprecated,stable", "--wrap-mode=default"],
     ),
     "openbmc/sdbusplus": PackageDef(
+        rev="f083bc1a64e1f94c99fc270b7c0856810f4be638",
         depends=[
             "nlohmann/json",
         ],


### PR DESCRIPTION
There are big changes going on in upstream where the PDI version has been bumped in order to support new bmcweb/phosphor-logging redfish registry features. We don't need this in 1110 and don't want to have to handle bringing these different commits into our 1110 branches so pin our CI to an older level of sdbusplus before these new features were introduced.

Tested:
- Confirmed phosphor-networkd now builds in 1110