### PR TITLE
build-setup: Add python modules to build AST2700

### DIFF
--- a/build-setup.sh
+++ b/build-setup.sh
@@ -239,6 +239,8 @@ elif [[ "${distro}" == ubuntu ]]; then
       libthread-queue-any-perl \
       locales \
       python3 \
+      python3-dev \
+      python3-setuptools \
       socat \
       subversion \
       texinfo \


### PR DESCRIPTION
The meta-aspeed/recipes-bsp/bootmcu-fw/bootmcu-fw_%.bb recipe requires additional python modules to compile.

Tested: Built rainiest machine from an ubuntu container.

Change-Id: I5303c0425913a4e4fe0c78ac3411a584a22f6e88