### PR TITLE
build-setup: Add git lfs

### DIFF
--- a/build-setup.sh
+++ b/build-setup.sh
@@ -232,6 +232,7 @@ elif [[ "${distro}" == ubuntu ]]; then
       file \
       gawk \
       git \
+      git-lfs \
       iputils-ping \
       libdata-dumper-simple-perl \
       lz4 \
@@ -247,6 +248,9 @@ elif [[ "${distro}" == ubuntu ]]; then
       vim \
       wget \
       zstd
+
+  # Setup git lfs
+  RUN git lfs install
 
   # Set the locale
   RUN locale-gen en_US.UTF-8


### PR DESCRIPTION
The git lfs (large file support) is required to access the internal hostfw image.

Tested: Ran the changes and checked the output of the script:
```
Setting up git-lfs (3.4.1-1ubuntu0.2) ...
...
STEP 4/13: RUN git lfs install
Git LFS initialized.
```

Change-Id: Ia9fc47791779996570c8f30cd972e28f8057ac11