### PR TITLE
build-unit-test-docker: sdbusplus: use pip for install

### DIFF
--- a/scripts/build-unit-test-docker
+++ b/scripts/build-unit-test-docker
@@ -294,7 +294,7 @@ packages = {
         build_type="meson",
         custom_post_dl=[
             "cd tools",
-            f"./setup.py install --root=/ --prefix={prefix}",
+            "python3 -m pip install --break-system-packages --root-user-action ignore .",
             "cd ..",
         ],
         config_flags=[


### PR DESCRIPTION
Currently sdbusplus uses a setup.py, which is a deprecated method for installing python packages.  If we use `pip` here, we can allow it to detect how sdbusplus specifies its installation directives, which will allow transition from the older setup.py to newer pyproject.toml method.


Change-Id: Ie956fc32972f4e0ef225a1f8c04d98642098b6a2