### PR TITLE
build-unit-test-docker: Add lldpd for LLDP support

### DIFF
--- a/scripts/build-unit-test-docker
+++ b/scripts/build-unit-test-docker
@@ -967,7 +967,9 @@ RUN apt-get update && apt-get dist-upgrade -yy && apt-get install -yy \
     valgrind \
     vim \
     wget \
-    xxd
+    xxd \
+    lldpd \
+    liblldpctl-dev
 
 RUN pip install --break-system-packages --upgrade "git+https://github.com/ibm/detect-secrets.git@master#egg=detect-secrets"
 


### PR DESCRIPTION
phosphor-networkd requires lldpctl library for its LLDP neighbor discovery feature. The build fails without lldpd development packages installed in the Docker image.

Change-Id: Ib872ba6eb5df72d33baa6591c430c5f69e806c02