### PR TITLE
build-qemu-robot-docker: Support HTTPS mirrors

### DIFF
--- a/scripts/build-qemu-robot-docker.sh
+++ b/scripts/build-qemu-robot-docker.sh
@@ -33,6 +33,18 @@ if [[ -n "${UBUNTU_MIRROR}" ]]; then
         echo \"deb ${UBUNTU_MIRROR} \$(. /etc/os-release && echo \$VERSION_CODENAME)-security main restricted universe multiverse\" >> /etc/apt/sources.list && \
         echo \"deb ${UBUNTU_MIRROR} \$(. /etc/os-release && echo \$VERSION_CODENAME)-proposed main restricted universe multiverse\" >> /etc/apt/sources.list && \
         echo \"deb ${UBUNTU_MIRROR} \$(. /etc/os-release && echo \$VERSION_CODENAME)-backports main restricted universe multiverse\" >> /etc/apt/sources.list"
+
+    # If the mirror uses HTTPS, the minimal base image has no ca-certificates,
+    # so TLS verification will fail.  Temporarily disable peer verification just
+    # long enough to install ca-certificates, then remove the override so all
+    # subsequent apt operations run with full certificate checking.
+    if [[ "${UBUNTU_MIRROR}" == https://* ]]; then
+        MIRROR="${MIRROR}
+RUN echo 'Acquire::https::Verify-Peer \"false\";' > /etc/apt/apt.conf.d/99temp-no-verify && \\
+    apt-get update && \\
+    apt-get install -y --no-install-recommends ca-certificates && \\
+    rm /etc/apt/apt.conf.d/99temp-no-verify"
+    fi
 fi
 
 PIP_MIRROR_CMD=""


### PR DESCRIPTION
When UBUNTU_MIRROR is used a certificate failure was seen. However using the build-unit-test-docker script I did not see the same failure.

Comparison of the scripts showed the build-unit-test-docker script contains a temporary disables TLS peer verification in order to install the ca-certificates. The build-qemu-robot-docker was not doing this override.

After adding the override I was able to build the docker environment using build-qemu-robot-docker.