### PR TITLE
build-unit-test-docker: Conditionally enable BuildKit

### DIFF
--- a/scripts/build-unit-test-docker
+++ b/scripts/build-unit-test-docker
@@ -815,10 +815,14 @@ class Docker:
         #                   is never written into any layer or printed to the
         #                   build log.
 
-        # Collect optional secret args before the build call.
-        secret_args: list = []
-        if os.environ.get("GITHUB_IBM_TOKEN", ""):
-            secret_args = ["--secret", "id=github_ibm_token,env=GITHUB_IBM_TOKEN"]
+        # When the token is present, use BuildKit so the --mount=type=secret
+        use_buildkit = bool(os.environ.get("GITHUB_IBM_TOKEN", ""))
+        secret_args: list = (
+            ["--secret", "id=github_ibm_token,env=GITHUB_IBM_TOKEN"]
+            if use_buildkit
+            else []
+        )
+        extra_env = {"DOCKER_BUILDKIT": "1"} if use_buildkit else {}
 
         container.build(
             proxy_args,
@@ -836,7 +840,7 @@ class Docker:
                 )
             ),
             _err_to_out=True,
-            _env={**os.environ, "DOCKER_BUILDKIT": "1"},
+            _env={**os.environ, **extra_env},
         )
 
 
@@ -976,7 +980,6 @@ RUN cat /etc/apt/sources.list.d/debug.list
 
 # Create base Dockerfile.
 dockerfile_base = f"""
-# syntax=docker/dockerfile:1
 FROM {docker_reg}/{distro}
 
 {mirror}


### PR DESCRIPTION
Before:
  File "/home/cnpalmer/ci_test_area/openbmc-build-scripts/./scripts/build-unit-test-docker", line 1132, in <module>
    Docker.build("base", docker_base_img_name, dockerfile_base)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/cnpalmer/ci_test_area/openbmc-build-scripts/./scripts/build-unit-test-docker", line 823, in build
    container.build(
    ~~~~~~~~~~~~~~~^
        proxy_args,
        ^^^^^^^^^^^
    ...<14 lines>...
        _env={**os.environ, "DOCKER_BUILDKIT": "1"},
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/usr/lib/python3/dist-packages/sh.py", line 1511, in __call__
    rc = self.__class__.RunningCommandCls(cmd, call_args, stdin, stdout, stderr)
  File "/usr/lib/python3/dist-packages/sh.py", line 734, in __init__
    self.wait()
    ~~~~~~~~~^^
  File "/usr/lib/python3/dist-packages/sh.py", line 796, in wait
    self.handle_command_exit_code(exit_code)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/sh.py", line 823, in handle_command_exit_code
    raise exc
sh.ErrorReturnCode_1:

To fix this error, enable BuildKit (DOCKER_BUILDKIT=1) only when GITHUB_IBM_TOKEN is set, avoiding a regression on systems that have Docker but not the buildx plugin.