### PR TITLE
Enable hostfw phal 

### DIFF
--- a/run-unit-test-docker.sh
+++ b/run-unit-test-docker.sh
@@ -28,6 +28,9 @@
 #   EXTRA_UNIT_TEST_ARGS:  Optional, pass arguments to unit-test.py
 #   INTERACTIVE: Optional, run a bash shell instead of unit-test.py
 #   http_proxy: Optional, run the container with proxy environment
+#   NEEDS_HOSTFW_SRC: Optional, set to a non-empty value to clone hostfw-src
+#                     and make it available inside the container. Automatically
+#                     set when UNIT_TEST_PKG=hostfw-src.
 
 # Trace bash processing. Set -e so when a step fails, we fail the build
 set -uo pipefail
@@ -46,6 +49,7 @@ NO_FORMAT_CODE="${NO_FORMAT_CODE:-}"
 NO_CPPCHECK="${NO_CPPCHECK:-}"
 INTERACTIVE="${INTERACTIVE:-}"
 http_proxy=${http_proxy:-}
+NEEDS_HOSTFW_SRC="${NEEDS_HOSTFW_SRC:-}"
 
 # Timestamp for job
 echo "Unit test build started, $(date)"
@@ -73,6 +77,36 @@ export BRANCH
 DOCKER_IMG_NAME=$(./scripts/build-unit-test-docker)
 export DOCKER_IMG_NAME
 
+# Clone hostfw-src on the host where ~/.ssh/ is available.
+# Automatically required when testing hostfw-src itself.
+if [ "${UNIT_TEST_PKG}" = "hostfw-src" ]; then
+    NEEDS_HOSTFW_SRC=1
+fi
+
+HOSTFW_SRC_DIR=""
+if [ -n "${NEEDS_HOSTFW_SRC}" ]; then
+    if [ "${UNIT_TEST_PKG}" = "hostfw-src" ]; then
+        echo "UNIT_TEST_PKG=hostfw-src, using existing ${WORKSPACE}/hostfw-src"
+        HOSTFW_SRC_DIR="${WORKSPACE}/hostfw-src"
+    else
+        HOSTFW_SRC_DIR=$(mktemp -d)
+        trap 'rm -rf "${HOSTFW_SRC_DIR}"' EXIT
+        echo "Cloning hostfw-src into ${HOSTFW_SRC_DIR}"
+        git clone git@github.ibm.com:open-power/hostfw-src.git \
+            "${HOSTFW_SRC_DIR}" || \
+            { echo "ERROR: Failed to clone hostfw-src. Ensure SSH key is configured for github.ibm.com."; exit 1; }
+        # Check out the requested BRANCH if it exists in hostfw-src, mirroring the
+        # revision-selection logic the old package mechanism used: match $BRANCH,
+        # fall back to the default branch (master/main) if not found.
+        if git -C "${HOSTFW_SRC_DIR}" ls-remote --heads origin "${BRANCH}" \
+                | grep -q "${BRANCH}"; then
+            git -C "${HOSTFW_SRC_DIR}" checkout "${BRANCH}"
+        else
+            echo "Branch '${BRANCH}' not found in hostfw-src, using default branch"
+        fi
+    fi
+fi
+
 # Allow the user to pass options through to unit-test.py:
 #   EXTRA_UNIT_TEST_ARGS="-r 100" ...
 EXTRA_UNIT_TEST_ARGS="${EXTRA_UNIT_TEST_ARGS:+,${EXTRA_UNIT_TEST_ARGS/ /,}}"
@@ -81,8 +115,14 @@ EXTRA_UNIT_TEST_ARGS="${EXTRA_UNIT_TEST_ARGS:+,${EXTRA_UNIT_TEST_ARGS/ /,}}"
 if [ "${INTERACTIVE}" ]; then
     UNIT_TEST="/bin/bash"
 else
+    UNIT_TEST_PKG_PATH="${UNIT_TEST_PKG}"
+    # When testing hostfw-src itself, point unit-test.py at the phal subdirectory
+    # which contains the meson.build — the hostfw-src root has no build system.
+    if [ "${UNIT_TEST_PKG}" = "hostfw-src" ]; then
+        UNIT_TEST_PKG_PATH="hostfw-src/phal"
+    fi
     UNIT_TEST="${UNIT_TEST_SCRIPT_DIR}/${UNIT_TEST_PY},-w,${DOCKER_WORKDIR},\
--p,${UNIT_TEST_PKG},-b,$BRANCH,\
+-p,${UNIT_TEST_PKG_PATH},-b,$BRANCH,\
 -v${TEST_ONLY:+,-t}${NO_FORMAT_CODE:+,-n}${NO_CPPCHECK:+,--no-cppcheck}\
 ${EXTRA_UNIT_TEST_ARGS}"
 fi
@@ -106,18 +146,58 @@ fi
 # the env to allow the home mount to work (no impact on non-podman systems)
 export PODMAN_USERNS="keep-id"
 
-# shellcheck disable=SC2086 # ${PROXY_ENV} and ${EXTRA_DOCKER_RUN_ARGS} are
-# meant to be split
+HOSTFW_VOLUME_ARG=""
+HOSTFW_PRE_CMD=""
+PHAL_PYTHONPATH=""
+if [ -n "${NEEDS_HOSTFW_SRC}" ]; then
+    # Prepare hostfw-src/phal inside the container before running tests.
+    # The source was cloned on the host and is available via the workspace mount.
+    PHAL_PYTHONPATH="${DOCKER_WORKDIR}/hostfw-src/ekb/public/common/generic/tools/sbe_tools/targeting"
+
+    LIBFDT_PC_CONTENT="prefix=/usr\n\
+libdir=\${prefix}/lib/x86_64-linux-gnu\n\
+includedir=\${prefix}/include\n\
+\n\
+Name: libfdt\n\
+Description: Flat Device Tree library\n\
+Version: 0\n\
+Libs: -L\${libdir} -lfdt\n\
+Cflags: -I\${includedir}\n"
+
+    HOSTFW_PREAMBLE="cd ${DOCKER_WORKDIR}/hostfw-src && \
+pip3 install --break-system-packages --root-user-action=ignore networkx && \
+sudo sh -c 'printf \"${LIBFDT_PC_CONTENT}\" > /usr/local/lib/pkgconfig/libfdt.pc' && \
+cd ${DOCKER_WORKDIR} && "
+
+    if [ "${UNIT_TEST_PKG}" = "hostfw-src" ]; then
+        HOSTFW_PRE_CMD="${HOSTFW_PREAMBLE}"
+    else
+        HOSTFW_PRE_CMD="${HOSTFW_PREAMBLE}meson setup /tmp/hostfw-phal-builddir \
+${DOCKER_WORKDIR}/hostfw-src/phal --prefix=/usr/local && \
+ninja -C /tmp/hostfw-phal-builddir && \
+sudo ninja -C /tmp/hostfw-phal-builddir install && \
+sudo ldconfig && "
+    fi
+
+    HOSTFW_VOLUME_ARG="-v ${HOSTFW_SRC_DIR}:${DOCKER_WORKDIR}/hostfw-src"
+fi
+
+# shellcheck disable=SC2086 # ${PROXY_ENV}, ${EXTRA_DOCKER_RUN_ARGS}, and
+# ${HOSTFW_VOLUME_ARG} are meant to be split
 docker run --cap-add=sys_admin --rm=true \
     --privileged=true \
     ${PROXY_ENV} \
     -u "$USER" \
-    -w "${DOCKER_WORKDIR}" -v "${WORKSPACE}":"${DOCKER_WORKDIR}" \
+    -w "${DOCKER_WORKDIR}" -v "${HOME}:${HOME}" \
+    -v "${WORKSPACE}":"${DOCKER_WORKDIR}" \
+    ${HOSTFW_VOLUME_ARG} \
     -e "MAKEFLAGS=${MAKEFLAGS}" \
+    -e "PYTHONPATH=${PHAL_PYTHONPATH}${PYTHONPATH:+:${PYTHONPATH}}" \
     ${EXTRA_DOCKER_RUN_ARGS:-} \
     -${INTERACTIVE:+i}t "${DOCKER_IMG_NAME}" \
-    "${UNIT_TEST_SCRIPT_DIR}/${DBUS_UNIT_TEST_PY}" -u "${UNIT_TEST}" \
-    -f "${DBUS_SYS_CONFIG_FILE}"
+    /bin/bash -c "${HOSTFW_PRE_CMD}\
+    ${UNIT_TEST_SCRIPT_DIR}/${DBUS_UNIT_TEST_PY} -u ${UNIT_TEST} \
+    -f ${DBUS_SYS_CONFIG_FILE}"
 
 # Timestamp for build
 echo "Unit test build completed, $(date)"

--- a/scripts/build-unit-test-docker
+++ b/scripts/build-unit-test-docker
@@ -583,7 +583,7 @@ FROM {docker_base_img_name}
                 f"Unhandled download type for {self.package}: {url}"
             )
 
-        cmd = f"curl -L {url} | tar -x"
+        cmd = f"curl --fail -L {url} | tar -x"
 
         if url.endswith(".bz2"):
             cmd += "j"
@@ -928,6 +928,7 @@ RUN apt-get update && apt-get dist-upgrade -yy && apt-get install -yy \
     curl \
     dbus \
     device-tree-compiler \
+    libfdt-dev \
     flex \
     g++-14 \
     gcc-14 \

--- a/scripts/build-unit-test-docker
+++ b/scripts/build-unit-test-docker
@@ -350,44 +350,6 @@ cmake_flags = " ".join(
         "-DCMAKE_MAKE_PROGRAM=ninja",
     ]
 )
-
-# Conditionally add hostfw-src package only if GITHUB_IBM_TOKEN is available
-# This package requires access to IBM's internal GitHub Enterprise (github.ibm.com)
-# To include this package, set the GITHUB_IBM_TOKEN environment variable before running:
-#   export GITHUB_IBM_TOKEN="your_token_here"
-# Without this token, the package will be skipped and the build will continue successfully.
-if os.environ.get("GITHUB_IBM_TOKEN"):
-    packages["hostfw-src"] = PackageDef(
-        url=(
-            lambda pkg, rev: f"https://github.ibm.com/open-power/hostfw-src/archive/{rev}.tar.gz"
-        ),
-        build_type="custom",
-        depends=[
-            "nlohmann/json",
-        ],
-        custom_post_dl=[
-            "pip3 install --break-system-packages --root-user-action=ignore networkx",
-        ],
-        build_steps=[
-            "cd phal",
-            (
-                "PYTHONPATH=$(pwd)/../ekb/public/common/generic/tools/sbe_tools/targeting"
-                f" meson setup builddir --prefix={prefix}"
-                " -Dtests=true -Dbuild_dtb_only=false"
-            ),
-            (
-                "PYTHONPATH=$(pwd)/../ekb/public/common/generic/tools/sbe_tools/targeting"
-                " ninja -C builddir"
-            ),
-            "ninja -C builddir install",
-        ],
-    )
-else:
-    print(
-        "Note: Skipping 'hostfw-src' package (requires GITHUB_IBM_TOKEN for github.ibm.com access)",
-        file=sys.stderr,
-    )
-
 meson_flags = " ".join(
     [
         "--wrap-mode=nodownload",
@@ -579,23 +541,10 @@ FROM {docker_base_img_name}
             self.pkg_def["rev"] = gerrit_rev
             return
 
-        git_url = f"https://github.com/{self.package}"
-        if self.package == "hostfw-src":
-            git_url = "git@github.ibm.com:open-power/hostfw-src.git"
-
         # Ask Github for all the branches.
-        try:
-            lookup = git("ls-remote", "--heads", git_url)
-        except Exception:
-            print(
-                f"Warning: Could not fetch branches for {self.package} from {git_url}",
-                file=sys.stderr,
-            )
-            # If the repository is not accessible (e.g., authentication required),
-            # fall back to the requested branch so custom archive URLs can still
-            # resolve a revision later in _url().
-            self.pkg_def["rev"] = branch
-            return
+        lookup = git(
+            "ls-remote", "--heads", f"https://github.com/{self.package}"
+        )
 
         # Find the branch matching {branch} (or fallback to master).
         #   This section is locked because we are modifying the PackageDef.
@@ -634,34 +583,21 @@ FROM {docker_base_img_name}
                 f"Unhandled download type for {self.package}: {url}"
             )
 
+        cmd = f"curl -L {url} | tar -x"
+
         if url.endswith(".bz2"):
-            tar_flags = "xj"
+            cmd += "j"
         elif url.endswith(".gz"):
-            tar_flags = "xz"
+            cmd += "z"
         else:
             raise NotImplementedError(
                 f"Unknown tar flags needed for {self.package}: {url}"
             )
 
-        if "github.ibm.com" in url and os.environ.get("GITHUB_IBM_TOKEN", ""):
-            # Use a BuildKit secret mount so the token is never written into
-            # any image layer or printed to the build log.  The secret value
-            # is read inside the container at build time and is not present in
-            # any layer history or build log line.
-            return (
-                f"--mount=type=secret,id=github_ibm_token "
-                f"sh -c 'curl --fail -L "
-                f'-H "Authorization: token $(cat /run/secrets/github_ibm_token)" '
-                f"{url} | tar -{tar_flags}'"
-            )
-
-        return f"curl --fail -L {url} | tar -{tar_flags}"
+        return cmd
 
     def _cmd_cd_srcdir(self) -> str:
         """Formulate the command necessary to 'cd' into the source dir."""
-        # Special case for hostfw-src: the archive extracts to hostfw-src-*
-        if self.package == "hostfw-src":
-            return "cd hostfw-src-*"
         return f"cd {self.package.split('/')[-1]}*"
 
     def _df_copycmds(self) -> str:
@@ -811,21 +747,11 @@ class Docker:
         #   Other unusual flags:
         #       --no-cache: Bypass the Docker cache if 'force_build'.
         #       --force-rm: Clean up Docker processes if they fail.
-        #       --secret:   Pass GITHUB_IBM_TOKEN as a BuildKit secret so it
-        #                   is never written into any layer or printed to the
-        #                   build log.
-
-        # Collect optional secret args before the build call.
-        secret_args: list = []
-        if os.environ.get("GITHUB_IBM_TOKEN", ""):
-            secret_args = ["--secret", "id=github_ibm_token,env=GITHUB_IBM_TOKEN"]
-
         container.build(
             proxy_args,
             "--network=host",
             "--force-rm",
             "--no-cache=true" if force_build else "--no-cache=false",
-            *secret_args,
             "-t",
             tag,
             "-",
@@ -836,7 +762,6 @@ class Docker:
                 )
             ),
             _err_to_out=True,
-            _env={**os.environ, "DOCKER_BUILDKIT": "1"},
         )
 
 
@@ -976,7 +901,6 @@ RUN cat /etc/apt/sources.list.d/debug.list
 
 # Create base Dockerfile.
 dockerfile_base = f"""
-# syntax=docker/dockerfile:1
 FROM {docker_reg}/{distro}
 
 {mirror}

--- a/scripts/build-unit-test-docker
+++ b/scripts/build-unit-test-docker
@@ -815,14 +815,10 @@ class Docker:
         #                   is never written into any layer or printed to the
         #                   build log.
 
-        # When the token is present, use BuildKit so the --mount=type=secret
-        use_buildkit = bool(os.environ.get("GITHUB_IBM_TOKEN", ""))
-        secret_args: list = (
-            ["--secret", "id=github_ibm_token,env=GITHUB_IBM_TOKEN"]
-            if use_buildkit
-            else []
-        )
-        extra_env = {"DOCKER_BUILDKIT": "1"} if use_buildkit else {}
+        # Collect optional secret args before the build call.
+        secret_args: list = []
+        if os.environ.get("GITHUB_IBM_TOKEN", ""):
+            secret_args = ["--secret", "id=github_ibm_token,env=GITHUB_IBM_TOKEN"]
 
         container.build(
             proxy_args,
@@ -840,7 +836,7 @@ class Docker:
                 )
             ),
             _err_to_out=True,
-            _env={**os.environ, **extra_env},
+            _env={**os.environ, "DOCKER_BUILDKIT": "1"},
         )
 
 
@@ -980,6 +976,7 @@ RUN cat /etc/apt/sources.list.d/debug.list
 
 # Create base Dockerfile.
 dockerfile_base = f"""
+# syntax=docker/dockerfile:1
 FROM {docker_reg}/{distro}
 
 {mirror}


### PR DESCRIPTION
Clone hostfw-src using the CI host's SSH credentials and make it
available to the unit test container through the workspace mount.
Build and install PHAL when required by dependent packages, and
support running unit tests directly against hostfw-src/phal.

The clone is skipped entirely unless the package under test actually
needs hostfw-src. Set NEEDS_HOSTFW_SRC=1 to opt in; it is set
automatically when UNIT_TEST_PKG=hostfw-src. This avoids a ~127 MiB
clone for packages that have no dependency on it.

When a clone is needed, it goes into a mktemp directory rather than
a fixed path under WORKSPACE, so it cannot clobber an active
checkout. The directory is cleaned up automatically on exit via trap.